### PR TITLE
Fix some flake8 errors

### DIFF
--- a/hammett/__init__.py
+++ b/hammett/__init__.py
@@ -9,8 +9,6 @@ from os.path import (
     split,
 )
 
-import hammett.mark as mark
-
 
 __version__ = '0.7.0'
 
@@ -44,7 +42,7 @@ class Globals:
         self.output = []
         self.result_db = None
         self.should_stop = False
-        
+
     def reset(self):
         self.__init__()
 
@@ -359,7 +357,7 @@ def main(verbose=False, fail_fast=False, quiet=False, filenames=None, drop_into_
 
     from hammett.impl import should_stop
     g.reset()
-    
+
     g.results = dict(success=0, failed=0, skipped=0, abort=0)
     g.verbose = verbose
     g.fail_fast = fail_fast
@@ -404,7 +402,6 @@ source_location=.
         dirname, filename = split(test_filename)
 
         import importlib.util
-        import sys
         if dirname.startswith('./'):
             dirname = dirname[2:]
 

--- a/hammett/impl.py
+++ b/hammett/impl.py
@@ -2,6 +2,7 @@ import os
 import sys
 from unittest import SkipTest
 from datetime import datetime
+from hammett import fixtures as built_in_fixtures
 
 import hammett
 from hammett.colors import (
@@ -77,7 +78,6 @@ def register_fixture(fixture, *args, autouse=False, scope='function'):
     fixtures[name] = fixture
 
 
-from hammett import fixtures as built_in_fixtures
 for fixture_name, fixture in built_in_fixtures.__dict__.items():
     if not fixture_name.startswith('_'):
         register_fixture(fixture)
@@ -292,7 +292,7 @@ def analyze_assert(tb):
             with open(os.path.join(hammett.g.orig_cwd, tb.tb_frame.f_code.co_filename)) as f:
                 source = f.read().split('\n')
         except FileNotFoundError:
-            hammett.print(f'Failed to analyze assert statement: file not found. Most likely there was a change of current directory.')
+            hammett.print('Failed to analyze assert statement: file not found. Most likely there was a change of current directory.')
             return
 
     line_no = tb.tb_frame.f_lineno - 1
@@ -342,15 +342,15 @@ def analyze_assert(tb):
         left_lines = left.split('\n')
         right_lines = right.split('\n')
         from difflib import unified_diff
-        for l in unified_diff(left_lines, right_lines, lineterm=''):
+        for line in unified_diff(left_lines, right_lines, lineterm=''):
             color = ''
-            if l:
+            if line:
                 color = {
                     '+': GREEN,
                     '-': RED,
                     '@': MAGENTA,
-                }.get(l[0], '')
-            hammett.print(f'{color}{l}{RESET_COLOR}')
+                }.get(line[0], '')
+            hammett.print(f'{color}{line}{RESET_COLOR}')
 
 
 SKIPPED = 'skipped'

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 import os
 import re
-from setuptools import setup, find_packages, Command
 from io import open
+from setuptools import Command, setup
 
 readme = open('README.rst', encoding='utf8').read()
 

--- a/tests/test_di.py
+++ b/tests/test_di.py
@@ -54,4 +54,3 @@ class DITests(unittest.TestCase):
         except FixturesUnresolvableException as e:
             assert str(e) == '''Could not resolve fixtures any more, have {'a': {'b'}} left.
 Available dependencies: dict_keys([])'''
-


### PR DESCRIPTION
Mostly just unused imports and trailing whitespace.

The big discovery is not in this changelist - it's that tests/test_analyze_assert.py fails if you clean trailing whitespace on the lines.

This means that your diffs produce trailing spaces, which is a little undesirable, but more, if someone edits tests/test_analyze_assert.py with an editor that automatically removes trailing whitespace, which is most of them these days, then they'll magically get new errors.

Thanks for this exciting project!